### PR TITLE
add API requests support

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -7,6 +7,8 @@ import duke.parsers.Parser;
 import duke.storage.Storage;
 import duke.ui.Ui;
 
+import java.io.IOException;
+
 /**
  * The Duke program is a simple Personal Assistant Chatbot
  * that helps a person to keep track of various things.
@@ -41,7 +43,7 @@ public class Duke {
             if (c instanceof ExitCommand) {
                 tryExitApp();
             }
-        } catch (DukeException e) {
+        } catch (DukeException | IOException e) {
             ui.showError(e.getMessage());
         }
     }

--- a/src/main/java/duke/api/ApiParser.java
+++ b/src/main/java/duke/api/ApiParser.java
@@ -1,0 +1,38 @@
+package duke.api;
+
+import com.fasterxml.jackson.databind.util.JSONPObject;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import duke.requests.LocationSearchUrlReq;
+import duke.commons.DukeException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * Class to handle all API requests.
+ */
+public class ApiParser {
+
+    /**
+     * Return names and coordinates of location search.
+     * @param param The query
+     * @return result The locations found
+     */
+    public static ArrayList<String> getLocationSearch(String param) throws IOException, DukeException {
+        ArrayList<String> result = new ArrayList<>();
+        LocationSearchUrlReq req = new LocationSearchUrlReq("https://developers.onemap.sg/commonapi/search?",
+                param);
+        JsonObject jsonRes = req.execute();
+
+        JsonArray arr = jsonRes.getAsJsonArray("results");
+        for (int i = 0; i < Integer.valueOf(String.valueOf(jsonRes.getAsJsonPrimitive("found")))
+                && i < 5; i++) {
+            result.add(arr.get(i).getAsJsonObject().get("SEARCHVAL").getAsString() + " ("
+                + arr.get(i).getAsJsonObject().get("LATITUDE").getAsString() + " : "
+                + arr.get(i).getAsJsonObject().get("LONGITUDE").getAsString() + ")");
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/duke/commands/Command.java
+++ b/src/main/java/duke/commands/Command.java
@@ -4,6 +4,8 @@ import duke.commons.DukeException;
 import duke.storage.Storage;
 import duke.ui.Ui;
 
+import java.io.IOException;
+
 /**
  * Abstract class representing individual duke.commands.
  */
@@ -14,5 +16,5 @@ public abstract class Command {
      * @param ui The user interface displaying events on the task list.
      * @param storage The duke.storage object containing task list.
      */
-    public abstract void execute(Ui ui, Storage storage) throws DukeException;
+    public abstract void execute(Ui ui, Storage storage) throws DukeException, IOException;
 }

--- a/src/main/java/duke/commands/LocationSearchCommand.java
+++ b/src/main/java/duke/commands/LocationSearchCommand.java
@@ -1,0 +1,36 @@
+package duke.commands;
+
+import duke.requests.LocationSearchUrlReq;
+import duke.commons.DukeException;
+import duke.storage.Storage;
+import duke.ui.Ui;
+import duke.api.ApiParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Class representing a command to send the test URL connection.
+ */
+public class LocationSearchCommand extends Command {
+    private String param;
+
+    public LocationSearchCommand(String param) {
+        this.param = param;
+    }
+
+    /**
+     * Executes this command with given param.
+     */
+    @Override
+    public void execute(Ui ui, Storage storage) throws IOException, DukeException {
+        ArrayList<String> result = ApiParser.getLocationSearch(param);
+
+        ui.show("These are the coordinates of your search:");
+        for (String output: result) {
+            ui.show(output);
+        }
+    }
+}

--- a/src/main/java/duke/parsers/Parser.java
+++ b/src/main/java/duke/parsers/Parser.java
@@ -7,6 +7,7 @@ import duke.commands.Command;
 import duke.commands.ExitCommand;
 import duke.commands.HelpCommand;
 import duke.commands.ListCommand;
+import duke.commands.LocationSearchCommand;
 import duke.commands.MarkDoneCommand;
 import duke.commands.ReminderCommand;
 import duke.commands.FreeTimeCommand;
@@ -14,6 +15,7 @@ import duke.commands.RescheduleCommand;
 import duke.commands.ViewScheduleCommand;
 import duke.commons.DukeException;
 import duke.commons.MessageUtil;
+
 
 /**
  * Parser for duke.commands entered by the duke.Duke user. It reads from standard input and
@@ -62,6 +64,8 @@ public class Parser {
             return new AddCommand(ParserUtil.createFixed(userInput));
         case "help":
             return new HelpCommand();
+        case "search":
+            return new LocationSearchCommand(getWord(userInput));
         default:
             throw new DukeException(MessageUtil.UNKNOWN_COMMAND);
         }

--- a/src/main/java/duke/requests/HttpReq.java
+++ b/src/main/java/duke/requests/HttpReq.java
@@ -20,6 +20,9 @@ public abstract class HttpReq {
      * @param param The parameters of the request
      */
     public HttpReq(String reqType, String url, String param) {
+        this.reqType = reqType;
+        this.url = url;
+        this.param = param;
     }
 
     /**

--- a/src/main/java/duke/requests/HttpReq.java
+++ b/src/main/java/duke/requests/HttpReq.java
@@ -1,0 +1,29 @@
+package duke.requests;
+
+import duke.commons.DukeException;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Abstract class representing individual HTTP requests.
+ */
+public abstract class HttpReq {
+    private String reqType;
+    private String url;
+    private String param;
+
+    /**
+     * Initialises HTTP Request parameters.
+     * @param reqType The request type
+     * @param url The request URL
+     * @param param The parameters of the request
+     */
+    public HttpReq(String reqType, String url, String param) {
+    }
+
+    /**
+     * Executes the HTTP Request.
+     */
+    public abstract void execute() throws DukeException, IOException;
+}

--- a/src/main/java/duke/requests/LocationSearchUrlReq.java
+++ b/src/main/java/duke/requests/LocationSearchUrlReq.java
@@ -26,8 +26,6 @@ public class LocationSearchUrlReq extends UrlReq {
      */
     public LocationSearchUrlReq(String url, String param) {
         super(url, param);
-        this.url = url;
-        this.param = param;
     }
 
     /**

--- a/src/main/java/duke/requests/LocationSearchUrlReq.java
+++ b/src/main/java/duke/requests/LocationSearchUrlReq.java
@@ -1,0 +1,52 @@
+package duke.requests;
+
+import com.google.gson.JsonElement;
+import duke.commons.DukeException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * URL request to OneMap API to get coordinates of location.
+ */
+public class LocationSearchUrlReq extends UrlReq {
+    private String paramType = "searchVal";
+    private String optionalVariables = "&returnGeom=Y&getAddrDetails=Y&pageNum=1";
+
+    /**
+     * Construct the URL Request.
+     * @param url The URL
+     * @param param The query
+     */
+    public LocationSearchUrlReq(String url, String param) {
+        super(url, param);
+        this.url = url;
+        this.param = param;
+    }
+
+    /**
+     * Executes the URL request to OneMap API.
+     * @return JSONObject The response from request
+     */
+    @Override
+    public JsonObject execute() throws DukeException, IOException {
+        URL url = new URL(this.url + paramType + "=" + param + optionalVariables);
+        URLConnection connection = url.openConnection();
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        String response = in.readLine();
+        in.close();
+
+        JsonParser jp = new JsonParser();
+        JsonElement root = jp.parse(response);
+        JsonObject result = root.getAsJsonObject();
+
+        return result;
+    }
+}

--- a/src/main/java/duke/requests/UrlReq.java
+++ b/src/main/java/duke/requests/UrlReq.java
@@ -1,0 +1,22 @@
+package duke.requests;
+
+import com.google.gson.JsonObject;
+import duke.commons.DukeException;
+
+import java.io.IOException;
+
+/**
+ * Abstract class representing individual URL requests.
+ */
+public abstract class UrlReq {
+    protected String url;
+    protected String param;
+
+    public UrlReq(String url, String param) {
+    }
+
+    /**
+     * Executes and sends the given URL request.
+     */
+    public abstract JsonObject execute() throws DukeException, IOException;
+}

--- a/src/main/java/duke/requests/UrlReq.java
+++ b/src/main/java/duke/requests/UrlReq.java
@@ -13,6 +13,8 @@ public abstract class UrlReq {
     protected String param;
 
     public UrlReq(String url, String param) {
+        this.url = url;
+        this.param = param;
     }
 
     /**


### PR DESCRIPTION
Add support for HTTP and URL requests to APIs.
Add apiParser class to handle requests to API.

Implement appropriate methods in apiParser.
apiParser serves as middleman between commands:

command calls api parser -> api parser creates url / http request obj -> request is sent -> request obj retrieves result -> request obj passes output to api parser -> api parser will parse the JSON output -> api parser returns the desired data to the command

Sample "search" command is created, though it is a placeholder and will likely be changed in the future.
Usage: search <location>
Example: search sentosa

* Important * - Duke will crash if there are extra spaces in the location query, will fix it soon!

┻━┻︵ \(°□°)/ ︵ ┻━┻