### PR TITLE
fix whitespace error in locationSearchUrlRequest and add Search Conversation

### DIFF
--- a/src/main/java/duke/commands/LocationSearchCommand.java
+++ b/src/main/java/duke/commands/LocationSearchCommand.java
@@ -14,7 +14,7 @@ public class LocationSearchCommand extends Command {
 
     public LocationSearchCommand(String param) throws DukeException {
         this.param = param;
-        result = ApiParser.getLocationSearch(param);
+        result = ApiParser.getLocationSearch(this.param);
     }
 
     /**

--- a/src/main/java/duke/logic/api/requests/LocationSearchUrlRequest.java
+++ b/src/main/java/duke/logic/api/requests/LocationSearchUrlRequest.java
@@ -41,6 +41,8 @@ public class LocationSearchUrlRequest extends UrlRequest {
         try {
             URL url = new URL(this.url + paramType + "=" + param + optionalVariables);
             URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
 
             BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
             response = in.readLine();

--- a/src/main/java/duke/logic/api/requests/LocationSearchUrlRequest.java
+++ b/src/main/java/duke/logic/api/requests/LocationSearchUrlRequest.java
@@ -27,7 +27,7 @@ public class LocationSearchUrlRequest extends UrlRequest {
      * @param param The query
      */
     public LocationSearchUrlRequest(String url, String param) {
-        super(url, param);
+        super(url, param.replace(" ", "+"));
     }
 
     /**

--- a/src/main/java/duke/logic/conversations/ConversationManager.java
+++ b/src/main/java/duke/logic/conversations/ConversationManager.java
@@ -83,6 +83,9 @@ public class ConversationManager {
         case "find":
             conversation = new FindConversation();
             break;
+        case "search":
+            conversation = new SearchConversation();
+            break;
         default:
             throw new DukeException(Messages.UNKNOWN_COMMAND);
         }

--- a/src/main/java/duke/logic/conversations/SearchConversation.java
+++ b/src/main/java/duke/logic/conversations/SearchConversation.java
@@ -1,9 +1,6 @@
 package duke.logic.conversations;
 
-import duke.commons.Messages;
 import duke.commons.MessagesPrompt;
-import duke.commons.exceptions.DukeDateTimeParseException;
-import duke.logic.parsers.ParserTimeUtil;
 
 public class SearchConversation extends Conversation {
     private static final String command = "search";

--- a/src/main/java/duke/logic/conversations/SearchConversation.java
+++ b/src/main/java/duke/logic/conversations/SearchConversation.java
@@ -1,0 +1,29 @@
+package duke.logic.conversations;
+
+import duke.commons.Messages;
+import duke.commons.MessagesPrompt;
+import duke.commons.exceptions.DukeDateTimeParseException;
+import duke.logic.parsers.ParserTimeUtil;
+
+public class SearchConversation extends Conversation {
+    private static final String command = "search";
+    private String location;
+
+    public SearchConversation() {
+        super();
+        prompt = MessagesPrompt.SEARCH_PROMPT_STARTER;
+    }
+
+    @Override
+    public void execute(String input) {
+        prompt = MessagesPrompt.SEARCH_PROMPT_SUCCESS;
+        location = input.replace(" ", "+");
+        buildResult();
+        setFinished(true);
+    }
+
+    @Override
+    protected void buildResult() {
+        result = command + " " + location;
+    }
+}


### PR DESCRIPTION
As above.

URL requests to OneMap API search will not crash if the input has whitespaces.

(⊙︿⊙ ; )