### PR TITLE
Complete edit feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     String javaFxVersion = '11'
 
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'

--- a/src/main/java/duke/logic/LogicManager.java
+++ b/src/main/java/duke/logic/LogicManager.java
@@ -7,6 +7,7 @@ import duke.commons.exceptions.DukeException;
 import duke.commons.exceptions.DukeUnknownCommandException;
 import duke.logic.commands.results.PanelResult;
 import duke.logic.conversations.ConversationManager;
+import duke.logic.edits.EditorManager;
 import duke.logic.parsers.Parser;
 import duke.model.Model;
 import duke.model.ModelManager;

--- a/src/main/java/duke/logic/commands/EditCommand.java
+++ b/src/main/java/duke/logic/commands/EditCommand.java
@@ -22,6 +22,7 @@ public class EditCommand extends Command {
         this.canSave = canSave;
         this.events = events;
     }
+
     /**
      * Executes this command and returns a text result.
      *

--- a/src/main/java/duke/logic/commands/EditCommand.java
+++ b/src/main/java/duke/logic/commands/EditCommand.java
@@ -4,6 +4,7 @@ import duke.commons.exceptions.CorruptedFileException;
 import duke.commons.exceptions.FileNotSavedException;
 import duke.logic.commands.results.CommandResultText;
 import duke.model.Model;
+import duke.model.lists.EventList;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -13,7 +14,14 @@ import java.util.logging.Logger;
  */
 public class EditCommand extends Command {
     private static final Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+    private static final String MESSAGE_EDIT_FAILURE = "Edit is cancelled. Changes are not saved.\n";
+    private boolean canSave;
+    private EventList events;
 
+    public EditCommand(boolean canSave, EventList events) {
+        this.canSave = canSave;
+        this.events = events;
+    }
     /**
      * Executes this command and returns a text result.
      *
@@ -21,8 +29,12 @@ public class EditCommand extends Command {
      */
     @Override
     public CommandResultText execute(Model model) throws FileNotSavedException, CorruptedFileException {
-        model.save();
-        logger.log(Level.FINE, "Event list is saved.");
-        return new CommandResultText(model.getEvents());
+        if (canSave) {
+            model.setEvents(events);
+            model.save();
+            logger.log(Level.FINE, "Event list is saved.");
+            return new CommandResultText(model.getEvents());
+        }
+        return new CommandResultText(MESSAGE_EDIT_FAILURE);
     }
 }

--- a/src/main/java/duke/logic/commands/EditorCommand.java
+++ b/src/main/java/duke/logic/commands/EditorCommand.java
@@ -1,9 +1,12 @@
 package duke.logic.commands;
 
 import duke.commons.exceptions.EmptyVenueException;
-import duke.logic.EditorManager;
+import duke.logic.edits.EditorManager;
 import duke.logic.commands.results.CommandResultText;
 import duke.model.Model;
+import duke.model.lists.EventList;
+
+import org.apache.commons.lang3.SerializationUtils;
 
 /**
  * Turns on the editing mode on SGTravel.
@@ -19,7 +22,8 @@ public class EditorCommand extends Command {
      */
     @Override
     public CommandResultText execute(Model model) throws EmptyVenueException {
-        EditorManager.activate(model.getEvents(), model.getEventVenues());
+        EventList events = SerializationUtils.clone(model.getEvents());
+        EditorManager.activate(events, model.getEventVenues());
         return new CommandResultText(MESSAGE_EDITOR);
     }
 }

--- a/src/main/java/duke/logic/commands/QuickEditCommand.java
+++ b/src/main/java/duke/logic/commands/QuickEditCommand.java
@@ -1,0 +1,42 @@
+package duke.logic.commands;
+
+import duke.commons.exceptions.ApiNullRequestException;
+import duke.commons.exceptions.ApiTimeoutException;
+import duke.commons.exceptions.CorruptedFileException;
+import duke.commons.exceptions.DukeDateTimeParseException;
+import duke.commons.exceptions.EventSelectionOutOfBoundsException;
+import duke.commons.exceptions.FileNotSavedException;
+import duke.logic.commands.results.CommandResultText;
+import duke.logic.edits.Editor;
+import duke.model.Event;
+import duke.model.Model;
+
+public class QuickEditCommand extends Command {
+    private static final String MESSAGE_EDIT_SUCCESS = "The following is successfully changed:\n";
+    private static final int DESCRIPTION = 0;
+    private static final int START_DATE = 1;
+    private static final int END_DATE = 2;
+    private int index;
+    private String[] descriptors;
+
+    private QuickEditCommand(int index) {
+        this.index = index;
+    }
+
+    public QuickEditCommand(int index, String... descriptors) {
+        this(index);
+        this.descriptors = descriptors;
+    }
+
+    @Override
+    public CommandResultText execute(Model model) throws ApiNullRequestException, ApiTimeoutException,
+            FileNotSavedException, CorruptedFileException, EventSelectionOutOfBoundsException,
+            DukeDateTimeParseException {
+        Event event = model.getEvents().get(index);
+        Editor.edit(descriptors[DESCRIPTION], event, DESCRIPTION);
+        Editor.edit(descriptors[START_DATE], event, START_DATE);
+        Editor.edit(descriptors[END_DATE], event, END_DATE);
+        model.save();
+        return new CommandResultText(MESSAGE_EDIT_SUCCESS + event);
+    }
+}

--- a/src/main/java/duke/logic/edits/Editor.java
+++ b/src/main/java/duke/logic/edits/Editor.java
@@ -1,0 +1,45 @@
+package duke.logic.edits;
+
+import duke.commons.exceptions.ApiNullRequestException;
+import duke.commons.exceptions.ApiTimeoutException;
+import duke.commons.exceptions.DukeDateTimeParseException;
+import duke.commons.exceptions.EventSelectionOutOfBoundsException;
+import duke.logic.api.ApiParser;
+import duke.logic.parsers.ParserTimeUtil;
+import duke.model.Event;
+
+public class Editor {
+    private static final int DESCRIPTION = 0;
+    private static final int START_DATE = 1;
+    private static final int END_DATE = 2;
+
+    public static void edit(String userInput, Event event, int eventField) throws EventSelectionOutOfBoundsException, ApiNullRequestException,
+            ApiTimeoutException, DukeDateTimeParseException {
+        switch (eventField) {
+        case DESCRIPTION:
+            editDescription(userInput, event);
+            break;
+        case START_DATE:
+            editStartDate(userInput, event);
+            break;
+        case END_DATE:
+            editEndDate(userInput, event);
+            break;
+        default:
+            throw new EventSelectionOutOfBoundsException();
+        }
+    }
+
+    private static void editDescription(String userInput, Event event) throws ApiNullRequestException, ApiTimeoutException {
+        event.setLocation(ApiParser.getLocationSearch(userInput));
+        event.setDescription(userInput);
+    }
+
+    private static void editStartDate(String userInput, Event event) throws DukeDateTimeParseException {
+        event.setStartDate(ParserTimeUtil.parseStringToDate(userInput));
+    }
+
+    private static void editEndDate(String userInput, Event event) throws DukeDateTimeParseException {
+        event.setEndDate(ParserTimeUtil.parseStringToDate(userInput));
+    }
+}

--- a/src/main/java/duke/logic/edits/Editor.java
+++ b/src/main/java/duke/logic/edits/Editor.java
@@ -8,13 +8,26 @@ import duke.logic.api.ApiParser;
 import duke.logic.parsers.ParserTimeUtil;
 import duke.model.Event;
 
+/**
+ * Editor that edits an Event object.
+ */
 public class Editor {
     private static final int DESCRIPTION = 0;
     private static final int START_DATE = 1;
     private static final int END_DATE = 2;
 
-    public static void edit(String userInput, Event event, int eventField) throws EventSelectionOutOfBoundsException, ApiNullRequestException,
-            ApiTimeoutException, DukeDateTimeParseException {
+    /**
+     * Edits an Event object.
+     * @param userInput The new information.
+     * @param event The Event object.
+     * @param eventField Integer indicating which field to edit.
+     * @throws EventSelectionOutOfBoundsException If the eventField does not corresponds to any component of Event.
+     * @throws ApiNullRequestException If the location does not exist.
+     * @throws ApiTimeoutException If the API request time out.
+     * @throws DukeDateTimeParseException If the date format is invalid.
+     */
+    public static void edit(String userInput, Event event, int eventField) throws EventSelectionOutOfBoundsException,
+            ApiNullRequestException, ApiTimeoutException, DukeDateTimeParseException {
         switch (eventField) {
         case DESCRIPTION:
             editDescription(userInput, event);
@@ -30,15 +43,35 @@ public class Editor {
         }
     }
 
-    private static void editDescription(String userInput, Event event) throws ApiNullRequestException, ApiTimeoutException {
+    /**
+     * Edits the description of an Event object.
+     * @param userInput The new description.
+     * @param event The Event object.
+     * @throws ApiNullRequestException If the user input is not a location.
+     * @throws ApiTimeoutException If the request time out.
+     */
+    private static void editDescription(String userInput, Event event) throws ApiNullRequestException,
+            ApiTimeoutException {
         event.setLocation(ApiParser.getLocationSearch(userInput));
         event.setDescription(userInput);
     }
 
+    /**
+     * Edits the start date of an Event object.
+     * @param userInput The new date.
+     * @param event The Event object.
+     * @throws DukeDateTimeParseException If the date format of user input is invalid.
+     */
     private static void editStartDate(String userInput, Event event) throws DukeDateTimeParseException {
         event.setStartDate(ParserTimeUtil.parseStringToDate(userInput));
     }
 
+    /**
+     * Edits the end date of an Event object.
+     * @param userInput The new date.
+     * @param event The Event object.
+     * @throws DukeDateTimeParseException If the date format of user input is invalid.
+     */
     private static void editEndDate(String userInput, Event event) throws DukeDateTimeParseException {
         event.setEndDate(ParserTimeUtil.parseStringToDate(userInput));
     }

--- a/src/main/java/duke/logic/edits/EditorManager.java
+++ b/src/main/java/duke/logic/edits/EditorManager.java
@@ -1,4 +1,4 @@
-package duke.logic;
+package duke.logic.edits;
 
 import duke.commons.exceptions.DukeException;
 import duke.commons.exceptions.EmptyVenueException;
@@ -63,11 +63,12 @@ public class EditorManager {
             throw new EventNotSelectedException();
         }
         assert (currentEvent != null) : "currentEvent must always exist when the lock is on";
-        EditorParser.parse(userInput, eventField, currentEvent);
+        boolean canSave = EditorParser.parse(userInput);
         if (isActive) {
+            Editor.edit(userInput, currentEvent, eventField);
             return PromptParser.parseCommand("editing...");
         }
-        return new EditCommand();
+        return new EditCommand(canSave, events);
     }
 
     /**

--- a/src/main/java/duke/logic/parsers/EditorParser.java
+++ b/src/main/java/duke/logic/parsers/EditorParser.java
@@ -1,51 +1,32 @@
 package duke.logic.parsers;
 
-import duke.commons.exceptions.DukeException;
-import duke.commons.exceptions.EventSelectionOutOfBoundsException;
-import duke.logic.EditorManager;
-import duke.logic.api.ApiParser;
-import duke.model.Event;
+import duke.logic.edits.EditorManager;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Parser for editing an Event object.
+ * Parser for editing operations.
  */
 public class EditorParser {
     private static final Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-    private static final int DESCRIPTION = 0;
-    private static final int START_DATE = 1;
-    private static final int END_DATE = 2;
 
     /**
-     * Parses the user input and eventField and edits the Event object accordingly.
-     * @param userInput The user input from the Ui.
-     * @param eventField The index of the field.
-     * @param event The Event object that is to be modified.
-     * @throws DukeException If the Event cannot be edited.
+     * Parses the user input.
+     * @param userInput The user input from ui.
+     * @return True if the edits can be saved.
      */
-    public static void parse(String userInput, int eventField, Event event) throws DukeException {
-        logger.log(Level.FINE, "Editing: " + userInput + " " + event);
+    public static boolean parse(String userInput) {
+        logger.log(Level.FINE, "Editor parsing user input");
         switch (userInput) {
-        case "end": case "close": case "x":
+        case "done": case "save": case "x":
             EditorManager.deactivate();
-            return;
-        default:
-        }
-        switch (eventField) {
-        case DESCRIPTION:
-            event.setLocation(ApiParser.getLocationSearch(userInput));
-            event.setDescription(userInput);
-            break;
-        case START_DATE:
-            event.setStartDate(ParserTimeUtil.parseStringToDate(userInput));
-            break;
-        case END_DATE:
-            event.setEndDate(ParserTimeUtil.parseStringToDate(userInput));
+            return true;
+        case "close": case "end": case "X":
+            EditorManager.deactivate();
             break;
         default:
-            throw new EventSelectionOutOfBoundsException();
         }
+        return false;
     }
 }

--- a/src/main/java/duke/logic/parsers/Parser.java
+++ b/src/main/java/duke/logic/parsers/Parser.java
@@ -19,6 +19,7 @@ import duke.logic.commands.ListCommand;
 import duke.logic.commands.LocationSearchCommand;
 import duke.logic.commands.MarkDoneCommand;
 import duke.logic.commands.PromptCommand;
+import duke.logic.commands.QuickEditCommand;
 import duke.logic.commands.RecommendationsCommand;
 import duke.logic.commands.RouteDeleteCommand;
 import duke.logic.commands.RouteEditCommand;
@@ -56,6 +57,11 @@ public class Parser {
             return new ViewScheduleCommand();
         case "edit":
             return new EditorCommand();
+        case "e":
+            return new QuickEditCommand(ParserUtil.getIntegerIndexInList(0, 4, inputBody),
+                    ParserUtil.getFieldInList(1, 4, inputBody),
+                    ParserUtil.getFieldInList(2, 4, inputBody),
+                    ParserUtil.getFieldInList(3, 4, inputBody));
         case "done":
             return new MarkDoneCommand(ParserUtil.getIntegerIndexInList(0, 1, inputBody));
         case "delete":
@@ -73,8 +79,9 @@ public class Parser {
         case "event":
             return new AddCommand(ParserUtil.createEvent(input));
         case "findPath":
-            return new FindPathCommand(input.strip().split(" ")[1], ParserUtil.getIntegerIndexInList(0, 2, inputBody),
-                    ParserUtil.getIntegerIndexInList(1, 2, inputBody));
+            return new FindPathCommand(ParserUtil.getFieldInList(0, 3, inputBody),
+                    ParserUtil.getIntegerIndexInList(1, 3, inputBody),
+                    ParserUtil.getIntegerIndexInList(2, 3, inputBody));
         case "recommend":
             return new RecommendationsCommand(ParserUtil.createRecommendation(input));
         case "cancel":
@@ -91,7 +98,8 @@ public class Parser {
                     ParserUtil.getFieldInList(2, 3, inputBody));
         case "routeNodeEdit":
             return new RouteNodeEditCommand(ParserUtil.getIntegerIndexInList(0, 3, inputBody),
-                    ParserUtil.getIntegerIndexInList(1, 3, inputBody), ParserUtil.getFieldInList(2, 4, inputBody),
+                    ParserUtil.getIntegerIndexInList(1, 3, inputBody),
+                    ParserUtil.getFieldInList(2, 4, inputBody),
                     ParserUtil.getFieldInList(3, 4, inputBody));
         case "routeDelete":
             return new RouteDeleteCommand(ParserUtil.getIntegerIndexInList(0, 1, inputBody));

--- a/src/main/java/duke/model/Event.java
+++ b/src/main/java/duke/model/Event.java
@@ -4,12 +4,13 @@ import duke.commons.exceptions.DukeException;
 import duke.logic.api.ApiParser;
 import duke.model.locations.Venue;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
  * Represents an event occurring at a particular venue between a certain time.
  */
-public class Event extends TaskWithDates {
+public class Event extends TaskWithDates implements Serializable {
     private Venue venue;
 
     /**

--- a/src/main/java/duke/model/Model.java
+++ b/src/main/java/duke/model/Model.java
@@ -27,7 +27,13 @@ public interface Model {
     EventList getEvents();
 
     /**
-     * Return map object.
+     * Replaces the events of this model with the new one.
+     * @param events The new events.
+     */
+    void setEvents(EventList events);
+
+    /**
+     * Returns map object.
      */
     CreateMap getMap();
 

--- a/src/main/java/duke/model/ModelManager.java
+++ b/src/main/java/duke/model/ModelManager.java
@@ -47,6 +47,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setEvents(EventList events) {
+        this.events = events;
+    }
+
+    @Override
     public RouteList getRoutes() {
         return routes;
     }

--- a/src/main/java/duke/model/Task.java
+++ b/src/main/java/duke/model/Task.java
@@ -1,9 +1,11 @@
 package duke.model;
 
+import java.io.Serializable;
+
 /**
  * Represents a generic task, which can be marked as done.
  */
-public class Task {
+public class Task implements Serializable {
     private String description;
     private boolean isDone;
 

--- a/src/main/java/duke/model/TaskWithDates.java
+++ b/src/main/java/duke/model/TaskWithDates.java
@@ -1,11 +1,12 @@
 package duke.model;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
  * Represents Tasks with a date field.
  */
-public class TaskWithDates extends Task {
+public class TaskWithDates extends Task implements Serializable {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 

--- a/src/main/java/duke/model/lists/EventList.java
+++ b/src/main/java/duke/model/lists/EventList.java
@@ -54,12 +54,17 @@ public class EventList implements Iterable<Event>, Listable<Event>, Serializable
     }
 
     public void sort() {
-        events.sort(Comparator.comparing(TaskWithDates::getStartDate));
+        events.sort(Comparator.comparing(TaskWithDates::getStartDate)
+                .thenComparing(TaskWithDates::getEndDate));
     }
 
+    /**
+     * Returns a shallow copy of the sorted EventList.
+     */
     public EventList getSortedList() {
         return new EventList(events.stream().sorted(
-                Comparator.comparing(TaskWithDates::getStartDate)).collect(Collectors.toList()));
+                Comparator.comparing(TaskWithDates::getStartDate)
+                        .thenComparing(TaskWithDates::getEndDate)).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/duke/model/lists/EventList.java
+++ b/src/main/java/duke/model/lists/EventList.java
@@ -4,6 +4,7 @@ import duke.commons.exceptions.DukeDuplicateTaskException;
 import duke.model.Event;
 import duke.model.TaskWithDates;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
 /**
  * Represents a list of Events and contains its related accessor methods.
  */
-public class EventList implements Iterable<Event>, Listable<Event> {
+public class EventList implements Iterable<Event>, Listable<Event>, Serializable {
     private List<Event> events;
 
     public EventList() {

--- a/src/main/java/duke/model/locations/Venue.java
+++ b/src/main/java/duke/model/locations/Venue.java
@@ -1,9 +1,11 @@
 package duke.model.locations;
 
+import java.io.Serializable;
+
 /**
  * Represents a location of an attraction.
  */
-public class Venue {
+public class Venue implements Serializable {
     private String address;
     private double latitude;
     private double longitude;

--- a/src/main/java/duke/ui/SidePanel.java
+++ b/src/main/java/duke/ui/SidePanel.java
@@ -38,8 +38,11 @@ public class SidePanel extends UiPart<AnchorPane> {
                         PointCard.getCard(result.getVenue(i), result.getVenueColor(i)));
             }
             description.setText(result.getDescription());
+            description.setVisible(true);
             startDate.setText(result.getStartDate());
+            startDate.setVisible(true);
             endDate.setText(result.getEndDate());
+            endDate.setVisible(true);
             setHighlight(result);
         }
     }

--- a/src/main/resources/css/mainStyle.css
+++ b/src/main/resources/css/mainStyle.css
@@ -66,14 +66,27 @@
     -fx-background-color: rgba(0, 30, 15, 0.8);
 }
 
+.side {
+    -fx-background-color: grey;
+}
+
 .sidePane {
     -fx-background-image: url("../images/sg.png");
     -fx-background-size: 400 300;
 }
 
+.info {
+    -fx-background-color : black;
+    -fx-border-width: 2;
+    -fx-border-color : rgba(255, 255, 255, 0.0);
+    -fx-background-radius : 5;
+    -fx-border-radius : 5;
+    -fx-text-fill: turquoise;
+}
+
 .highlight {
     -fx-border-width: 2;
-    -fx-border-color: white;
+    -fx-border-color: khaki;
 }
 
 #LocationCard {

--- a/src/main/resources/view/SidePanel.fxml
+++ b/src/main/resources/view/SidePanel.fxml
@@ -5,13 +5,13 @@
 
 <?import javafx.geometry.Insets?>
 
-<AnchorPane prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane styleClass="side" prefHeight="600.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
     <AnchorPane fx:id="miniMap" styleClass="sidePane" StackPane.alignment="TOP_CENTER" prefHeight="300.0" prefWidth="400.0"/>
     <StackPane fx:id="taskContainer" layoutY="300.0" prefHeight="300.0"
                prefWidth="400.0">
-        <Label fx:id="description" StackPane.alignment="TOP_CENTER"/>
-        <Label fx:id="startDate" StackPane.alignment="CENTER"/>
-        <Label fx:id="endDate" StackPane.alignment="BOTTOM_CENTER"/>
+        <Label fx:id="description" StackPane.alignment="TOP_CENTER" styleClass="info" visible="false"/>
+        <Label fx:id="startDate" StackPane.alignment="CENTER" styleClass="info" visible="false"/>
+        <Label fx:id="endDate" StackPane.alignment="BOTTOM_CENTER" styleClass="info" visible="false"/>
         <padding>
             <Insets bottom="100.0" left="5.0" right="5.0" top="100.0"/>
         </padding>

--- a/src/test/java/duke/ModelStub.java
+++ b/src/test/java/duke/ModelStub.java
@@ -37,6 +37,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setEvents(EventList events) {
+        this.events = events;
+    }
+
+    @Override
     public EventList getEvents() {
         return events;
     }
@@ -57,7 +62,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void save() throws CorruptedFileException, FileNotSavedException {
+    public void save() {
         System.out.println("");
     }
 

--- a/src/test/java/duke/logic/EditorManagerTest.java
+++ b/src/test/java/duke/logic/EditorManagerTest.java
@@ -6,6 +6,7 @@ import duke.commons.exceptions.EventNotSelectedException;
 import duke.logic.commands.EditCommand;
 import duke.logic.commands.PromptCommand;
 import duke.logic.commands.results.PanelResult;
+import duke.logic.edits.EditorManager;
 import duke.model.Event;
 import duke.model.lists.EventList;
 import duke.model.lists.VenueList;

--- a/src/test/java/duke/logic/commands/CommandTest.java
+++ b/src/test/java/duke/logic/commands/CommandTest.java
@@ -1,5 +1,6 @@
 package duke.logic.commands;
 
+import duke.model.lists.EventList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,7 +13,8 @@ class CommandTest {
         assertTrue(new ListCommand() instanceof Command);
         assertTrue(new ExitCommand() instanceof Command);
         assertTrue(new EditorCommand() instanceof Command);
-        assertTrue(new EditCommand() instanceof Command);
+        assertTrue(new EditCommand(true, new EventList()) instanceof Command);
+        assertTrue(new EditCommand(false, new EventList()) instanceof Command);
         assertTrue(new PromptCommand("hi") instanceof Command);
         assertTrue(new ViewScheduleCommand() instanceof Command);
     }

--- a/src/test/java/duke/logic/commands/EditCommandTest.java
+++ b/src/test/java/duke/logic/commands/EditCommandTest.java
@@ -1,0 +1,27 @@
+package duke.logic.commands;
+
+import duke.ModelStub;
+import duke.commons.exceptions.CorruptedFileException;
+import duke.commons.exceptions.FileNotSavedException;
+import duke.logic.commands.results.CommandResultText;
+import duke.model.lists.EventList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class EditCommandTest {
+
+    @Test
+    void execute() throws FileNotSavedException, CorruptedFileException {
+        ModelStub modelStub = new ModelStub();
+        EditCommand editCommand = new EditCommand(false, new EventList());
+        CommandResultText resultText = editCommand.execute(modelStub);
+        assertEquals(resultText.getMessage(), "Edit is cancelled. Changes are not saved.\n");
+        assertNotEquals(resultText.getMessage(), "Edit is cancelled. Changes are not saved.");
+        EditCommand editCommand1 = new EditCommand(true, new EventList());
+        CommandResultText resultText1 = editCommand1.execute(modelStub);
+        assertEquals(resultText1.getMessage(), "Here are the list of events:\n");
+        assertNotEquals(resultText1.getMessage(), "Here are the list of events:");
+    }
+}

--- a/src/test/java/duke/logic/edits/EditorManagerTest.java
+++ b/src/test/java/duke/logic/edits/EditorManagerTest.java
@@ -1,4 +1,4 @@
-package duke.logic;
+package duke.logic.edits;
 
 import duke.commons.exceptions.DukeException;
 import duke.commons.exceptions.EmptyVenueException;
@@ -6,7 +6,6 @@ import duke.commons.exceptions.EventNotSelectedException;
 import duke.logic.commands.EditCommand;
 import duke.logic.commands.PromptCommand;
 import duke.logic.commands.results.PanelResult;
-import duke.logic.edits.EditorManager;
 import duke.model.Event;
 import duke.model.lists.EventList;
 import duke.model.lists.VenueList;

--- a/src/test/java/duke/logic/edits/EditorTest.java
+++ b/src/test/java/duke/logic/edits/EditorTest.java
@@ -1,0 +1,48 @@
+package duke.logic.edits;
+
+import duke.commons.exceptions.ApiNullRequestException;
+import duke.commons.exceptions.DukeDateTimeParseException;
+import duke.commons.exceptions.DukeException;
+import duke.commons.exceptions.EventSelectionOutOfBoundsException;
+import duke.logic.parsers.ParserTimeUtil;
+import duke.model.Event;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EditorTest {
+    private static final int DESCRIPTION = 0;
+    private static final int START_DATE = 1;
+    private static final int END_DATE = 2;
+
+    @Test
+    void edit() throws DukeException {
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        assertEquals(event.getDescription(), "Pulau Ubin");
+        Editor.edit("Geylang", event, DESCRIPTION);
+        assertEquals(event.getDescription(), "Geylang");
+        Editor.edit("Geylang", event, DESCRIPTION);
+        assertEquals(event.getDescription(), "Geylang");
+        assertThrows(ApiNullRequestException.class, () -> Editor.edit("gwhore", event, DESCRIPTION));
+        assertEquals(event.getDescription(), "Geylang");
+        assertNotEquals(event.getDescription(), "gwhore");
+        assertThrows(DukeDateTimeParseException.class, () -> Editor.edit("non", event, START_DATE));
+        assertThrows(DukeDateTimeParseException.class, () -> Editor.edit("non", event, END_DATE));
+        LocalDateTime date = ParserTimeUtil.parseStringToDate("01/01/18");
+        Editor.edit("01/01/18", event, START_DATE);
+        assertEquals(event.getStartDate().toLocalDate(), date.toLocalDate());
+        assertNotEquals(event.getStartDate(), startDate);
+        Editor.edit("02/02/18", event, END_DATE);
+        assertEquals(event.getEndDate().toLocalDate(), ParserTimeUtil.parseStringToDate("02/02/18").toLocalDate());
+        assertNotEquals(event.getEndDate(), endDate);
+        assertThrows(EventSelectionOutOfBoundsException.class, () -> Editor.edit("meow", event, -1));
+        assertThrows(EventSelectionOutOfBoundsException.class, () -> Editor.edit("meow", event, 3));
+    }
+}

--- a/src/test/java/duke/model/EventTest.java
+++ b/src/test/java/duke/model/EventTest.java
@@ -1,0 +1,67 @@
+package duke.model;
+
+import duke.commons.exceptions.DukeException;
+import duke.logic.parsers.ParserTimeUtil;
+import duke.model.locations.Venue;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventTest {
+    private Venue v1 = new Venue("YEW TEE INDUSTRIAL ESTATE", 1.3973210291170202, 103.753758637401, 0, 0);
+    private Venue v2 = new Venue("Tuas Checkpoint", 1.34942405517095, 103.636127935782, 0, 0);
+
+    @Test
+    void testToString() throws DukeException {
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        assertEquals(event.toString(), "[E][✘] Pulau Ubin between " + startDate + " and " + endDate);
+        assertNotEquals(event.toString(), "");
+    }
+
+    @Test
+    void getLocation() throws DukeException {
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        assertNotEquals(event.getLocation(), v1);
+        event.setLocation(v1);
+        assertEquals(event.getLocation(), v1);
+    }
+
+    @Test
+    void setLocation() throws DukeException {
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        event.setLocation(v1);
+        assertEquals(event.getLocation(), v1);
+        event.setLocation(v1);
+        assertEquals(event.getLocation(), v1);
+        event.setLocation(v2);
+        assertEquals(event.getLocation(), v2);
+    }
+
+    @Test
+    void isSameTask() throws DukeException {
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        Event event1 = new Event("Pulau Ubin", startDate, endDate);
+        assertTrue(event.isSameTask(event1));
+        assertTrue(event1.isSameTask(event));
+        event.setLocation(v1);
+        assertFalse(event.isSameTask(event1));
+        assertFalse(event1.isSameTask(event));
+        event1.setLocation(v1);
+        assertTrue(event.isSameTask(event1));
+        assertTrue(event1.isSameTask(event));
+    }
+}

--- a/src/test/java/duke/model/lists/EventListTest.java
+++ b/src/test/java/duke/model/lists/EventListTest.java
@@ -1,0 +1,236 @@
+package duke.model.lists;
+
+import duke.commons.exceptions.DukeDuplicateTaskException;
+import duke.commons.exceptions.DukeException;
+import duke.logic.parsers.ParserTimeUtil;
+import duke.model.Event;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventListTest {
+
+    @Test
+    void add() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        events.add(event);
+        assertThrows(DukeDuplicateTaskException.class, () -> events.add(event));
+    }
+
+    @Test
+    void isEmpty() throws DukeException {
+        EventList events = new EventList();
+        assertTrue(events.isEmpty());
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        events.add(event);
+        assertFalse(events.isEmpty());
+        Event event1 = new Event("Orchard", startDate, endDate);
+        events.add(event1);
+        assertFalse(events.isEmpty());
+    }
+
+    @Test
+    void contains() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        assertFalse(events.contains(event));
+        events.add(event);
+        assertTrue(events.contains(event));
+    }
+
+    @Test
+    void size() throws DukeException {
+        EventList events = new EventList();
+        assertEquals(events.size(), 0);
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        events.add(event);
+        assertEquals(events.size(), 1);
+        events.remove(0);
+        assertEquals(events.size(), 0);
+    }
+
+    @Test
+    void get() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate, endDate);
+        assertThrows(IndexOutOfBoundsException.class, () -> events.get(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> events.get(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> events.get(-1));
+        events.add(event);
+        assertEquals(events.get(0), event);
+        assertThrows(IndexOutOfBoundsException.class, () -> events.get(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> events.get(-1));
+    }
+
+    @Test
+    void sort() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate.plusDays(5), endDate);
+        Event event1 = new Event("Woodlands", startDate.minusDays(2), endDate);
+        Event event2 = new Event("Jurong east", startDate, endDate.plusDays(5));
+        Event event3 = new Event("Kranji", startDate, endDate.minusDays(2));
+        Event event4 = new Event("Tampines mrt", startDate, endDate);
+        events.add(event);
+        events.add(event1);
+        events.add(event2);
+        events.add(event3);
+        events.add(event4);
+        events.sort();
+        assertEquals(events.get(0), event1);
+        assertEquals(events.get(1), event3);
+        assertEquals(events.get(2), event4);
+        assertEquals(events.get(3), event2);
+        assertEquals(events.get(4), event);
+        events.sort();
+        assertEquals(events.get(0), event1);
+        assertEquals(events.get(1), event3);
+        assertEquals(events.get(2), event4);
+        assertEquals(events.get(3), event2);
+        assertEquals(events.get(4), event);
+        Event event5 = new Event("City Hall mrt", startDate.minusDays(10), endDate);
+        events.add(event5);
+        events.sort();
+        assertEquals(events.get(0), event5);
+        assertEquals(events.get(1), event1);
+        assertEquals(events.get(2), event3);
+        assertEquals(events.get(3), event4);
+        assertEquals(events.get(4), event2);
+        assertEquals(events.get(5), event);
+    }
+
+    @Test
+    void getSortedList() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate.plusDays(5), endDate);
+        Event event1 = new Event("Woodlands", startDate.minusDays(2), endDate);
+        Event event2 = new Event("Jurong east", startDate, endDate.plusDays(5));
+        Event event3 = new Event("Kranji", startDate, endDate.minusDays(2));
+        Event event4 = new Event("Tampines mrt", startDate, endDate);
+        events.add(event);
+        events.add(event1);
+        events.add(event2);
+        events.add(event3);
+        events.add(event4);
+        EventList events1 = events.getSortedList();
+        assertEquals(events1.get(0), event1);
+        assertEquals(events1.get(1), event3);
+        assertEquals(events1.get(2), event4);
+        assertEquals(events1.get(3), event2);
+        assertEquals(events1.get(4), event);
+        EventList events2 = events.getSortedList();
+        assertNotEquals(events2, events1);
+        Event event5 = new Event("City Hall mrt", startDate.minusDays(10), endDate);
+        events.add(event5);
+        events1 = events.getSortedList();
+        assertEquals(events1.get(0), event5);
+        assertEquals(events1.get(1), event1);
+        assertEquals(events1.get(2), event3);
+        assertEquals(events1.get(3), event4);
+        assertEquals(events1.get(4), event2);
+        assertEquals(events1.get(5), event);
+        assertEquals(events.get(0), event);
+        assertEquals(events.get(1), event1);
+        assertEquals(events.get(2), event2);
+        assertEquals(events.get(3), event3);
+        assertEquals(events.get(4), event4);
+        assertEquals(events.get(5), event5);
+    }
+
+    @Test
+    void iterator() throws DukeException {
+        EventList events = new EventList();
+        int i = 0;
+        for (Event e: events) {
+            assertEquals(e, events.get(i));
+            i++;
+        }
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate.plusDays(5), endDate);
+        Event event1 = new Event("Woodlands", startDate.minusDays(2), endDate);
+        Event event2 = new Event("Jurong east", startDate, endDate.plusDays(5));
+        Event event3 = new Event("Kranji", startDate, endDate.minusDays(2));
+        Event event4 = new Event("Tampines mrt", startDate, endDate);
+        events.add(event);
+        events.add(event1);
+        events.add(event2);
+        events.add(event3);
+        events.add(event4);
+        i = 0;
+        for (Event e: events) {
+            assertEquals(e, events.get(i));
+            i++;
+        }
+    }
+
+    @Test
+    void setEvents() throws DukeException {
+        List<Event> events = new ArrayList<>();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate.plusDays(5), endDate);
+        Event event1 = new Event("Woodlands", startDate.minusDays(2), endDate);
+        Event event2 = new Event("Jurong east", startDate, endDate.plusDays(5));
+        Event event3 = new Event("Kranji", startDate, endDate.minusDays(2));
+        Event event4 = new Event("Tampines mrt", startDate, endDate);
+        events.add(event);
+        events.add(event1);
+        events.add(event2);
+        events.add(event3);
+        events.add(event4);
+        EventList eventList = new EventList();
+        eventList.setEvents(events);
+        events.add(event2);
+        assertThrows(DukeDuplicateTaskException.class, () -> eventList.setEvents(events));
+    }
+
+    @Test
+    void remove() throws DukeException {
+        EventList events = new EventList();
+        LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
+        LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
+        Event event = new Event("Pulau Ubin", startDate.plusDays(5), endDate);
+        Event event1 = new Event("Woodlands", startDate.minusDays(2), endDate);
+        Event event2 = new Event("Jurong east", startDate, endDate.plusDays(5));
+        Event event3 = new Event("Kranji", startDate, endDate.minusDays(2));
+        Event event4 = new Event("Tampines mrt", startDate, endDate);
+        events.add(event);
+        events.add(event1);
+        events.add(event2);
+        events.add(event3);
+        events.add(event4);
+        assertTrue(events.contains(event));
+        events.remove(0);
+        assertFalse(events.contains(event));
+        events.remove(0);
+        assertFalse(events.contains(event1));
+        events.remove(0);
+        assertFalse(events.contains(event2));
+        assertThrows(IndexOutOfBoundsException.class, () -> events.remove(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> events.remove(2));
+    }
+}

--- a/src/test/java/duke/model/lists/EventListTest.java
+++ b/src/test/java/duke/model/lists/EventListTest.java
@@ -72,7 +72,7 @@ class EventListTest {
         EventList events = new EventList();
         LocalDateTime startDate = ParserTimeUtil.parseStringToDate("12/12/12");
         LocalDateTime endDate = ParserTimeUtil.parseStringToDate("06/06/18");
-        Event event = new Event("Pulau Ubin", startDate, endDate);
+        final Event event = new Event("Pulau Ubin", startDate, endDate);
         assertThrows(IndexOutOfBoundsException.class, () -> events.get(0));
         assertThrows(IndexOutOfBoundsException.class, () -> events.get(1));
         assertThrows(IndexOutOfBoundsException.class, () -> events.get(-1));


### PR DESCRIPTION
- Add more tests
- Edit feature usage:
    - Type ```edit``` to turn on edit mode
    - Use arrow keys ⬇️ ⬆️ ⬅️ ➡️ to navigate, Enter key ↩️ to select Event, Escape ❌ key to unselect event
    - Once Event is selected, type whatever you want it to be updated to followed by the Enter key ↩️
         - e.g. ```East Coast Park``` or ```12/12/12``` or ```Mon```
    - To save the edits, type ```x``` or ```done``` or ```save```
    - To **not** save the edits, type ```X``` or ```close``` or ```end```
    - Typing any of these exits edit mode ```x```, ```done```, ```save```, ```X```, ```close``` or ```end```