### PR TITLE
fix bugs in Route command

### DIFF
--- a/src/main/java/duke/commons/Messages.java
+++ b/src/main/java/duke/commons/Messages.java
@@ -67,6 +67,8 @@ public class Messages {
     public static final String ERROR_ROUTE_NODE_DUPLICATE = "Node already exists! :-(";
     public static final String ERROR_ROUTE_NODE_NOT_FOUND = "☢ Route not found! :-(";
 
+    public static final String ERROR_ROUTE_GENERATE_FAIL = "The Route failed to generate, try other locations :-(";
+
     public static final String ERROR_CATEGORY_NOT_FOUND = "Category does not exists! :-(";
 
     public static final String ANOMALY_FOUND = "⚡ Anomaly detected! Please check your tasks. :-(";

--- a/src/main/java/duke/commons/exceptions/RouteGenerateFailException.java
+++ b/src/main/java/duke/commons/exceptions/RouteGenerateFailException.java
@@ -1,0 +1,16 @@
+package duke.commons.exceptions;
+
+import duke.commons.Messages;
+
+/**
+ * Exception thrown when a route cannot be generated.
+ */
+public class RouteGenerateFailException extends DukeException {
+
+    /**
+     * Constructs the Exception.
+     */
+    public RouteGenerateFailException() {
+        super(Messages.ERROR_ROUTE_GENERATE_FAIL);
+    }
+}

--- a/src/main/java/duke/logic/PathFinder.java
+++ b/src/main/java/duke/logic/PathFinder.java
@@ -53,7 +53,7 @@ public class PathFinder {
         case MRT:
             return findTrainRoute(start, end);
         default:
-            return findMixedRoute(start, end);
+           return findMixedRoute(start, end);
         }
     }
 
@@ -449,6 +449,8 @@ public class PathFinder {
                 break;
             }
         }
+
+
         return result;
     }
 

--- a/src/main/java/duke/logic/commands/FindPathCommand.java
+++ b/src/main/java/duke/logic/commands/FindPathCommand.java
@@ -38,9 +38,11 @@ public class FindPathCommand extends Command {
         case "onlyBus":
             this.constraint = Constraint.BUS;
             break;
+        /*
         case "Hybrid":
             this.constraint = Constraint.MIXED;
             break;
+         */
         default:
             this.constraint = Constraint.CAR;
             break;

--- a/src/main/java/duke/logic/commands/RouteManagerNearbyCommand.java
+++ b/src/main/java/duke/logic/commands/RouteManagerNearbyCommand.java
@@ -1,6 +1,7 @@
 package duke.logic.commands;
 
 import duke.commons.exceptions.ApiException;
+import duke.commons.exceptions.QueryOutOfBoundsException;
 import duke.logic.commands.results.CommandResultImage;
 import duke.model.Model;
 
@@ -14,7 +15,7 @@ public class RouteManagerNearbyCommand extends Command {
      * @param model The model object containing event list.
      */
     @Override
-    public CommandResultImage execute(Model model) throws ApiException {
+    public CommandResultImage execute(Model model) throws ApiException, QueryOutOfBoundsException {
         int routeIndex = model.getRouteManager().getRouteIndex() - 1;
         int nodeIndex = model.getRouteManager().getNodeIndex() - 1;
         RouteNodeNeighboursCommand command = new RouteNodeNeighboursCommand(routeIndex, nodeIndex);

--- a/src/main/java/duke/logic/commands/RouteNodeAddCommand.java
+++ b/src/main/java/duke/logic/commands/RouteNodeAddCommand.java
@@ -57,6 +57,7 @@ public class RouteNodeAddCommand extends Command {
             Route route = model.getRoutes().get(indexRoute);
             if (isEmptyIndexNode) {
                 route.addNode(node);
+                indexNode = route.getNumNodes() - 1;
             } else if (indexNode >= 0) {
                 route.addNode(node, indexNode);
             } else {

--- a/src/main/java/duke/logic/commands/RouteNodeShowCommand.java
+++ b/src/main/java/duke/logic/commands/RouteNodeShowCommand.java
@@ -52,25 +52,29 @@ public class RouteNodeShowCommand extends Command {
     @Override
     public CommandResultImage execute(Model model) throws QueryOutOfBoundsException,
             ApiException {
-        Route route = model.getRoutes().get(indexRoute);
-        RouteNode node = model.getRoutes().get(indexRoute).getNode(indexNode);
-        String rgb = RED_VALUE_OTHER + "," + GREEN_VALUE_OTHER + "," + BLUE_VALUE_OTHER;
+        try {
+            Route route = model.getRoutes().get(indexRoute);
+            RouteNode node = model.getRoutes().get(indexRoute).getNode(indexNode);
+            String rgb = RED_VALUE_OTHER + "," + GREEN_VALUE_OTHER + "," + BLUE_VALUE_OTHER;
 
-        String param;
-        if (node instanceof BusStop) {
-            param = ((BusStop) node).getBusCode();
-        } else {
-            param = node.getAddress();
+            String param;
+            if (node instanceof BusStop) {
+                param = ((BusStop) node).getBusCode();
+            } else {
+                param = node.getAddress();
+            }
+
+            Venue query = ApiParser.getLocationSearch(param);
+            ArrayList<String> points = generateOtherPoints(route, node, indexNode);
+
+            Image image = ApiParser.getStaticMap(ApiParser.generateStaticMapParams(DIMENSIONS, DIMENSIONS, ZOOM_LEVEL,
+                    String.valueOf(query.getLatitude()), String.valueOf(query.getLongitude()), "",
+                    generateLineParam(points, rgb), generatePointParam(route, node)));
+
+            return new CommandResultImage(Messages.PROMPT_ROUTE_SELECTOR_DISPLAY + node.getDisplayInfo(), image);
+        } catch (IndexOutOfBoundsException e) {
+            throw new QueryOutOfBoundsException(String.valueOf(indexNode));
         }
-
-        Venue query = ApiParser.getLocationSearch(param);
-        ArrayList<String> points = generateOtherPoints(route, node, indexNode);
-
-        Image image = ApiParser.getStaticMap(ApiParser.generateStaticMapParams(DIMENSIONS, DIMENSIONS, ZOOM_LEVEL,
-                String.valueOf(query.getLatitude()), String.valueOf(query.getLongitude()), "",
-                generateLineParam(points, rgb), generatePointParam(route, node)));
-
-        return new CommandResultImage(Messages.PROMPT_ROUTE_SELECTOR_DISPLAY + node.getDisplayInfo(),image);
     }
 
     /**

--- a/src/main/java/duke/logic/commands/results/CommandResultText.java
+++ b/src/main/java/duke/logic/commands/results/CommandResultText.java
@@ -63,7 +63,7 @@ public class CommandResultText extends CommandResult {
             if (node instanceof BusStop) {
                 message += ((BusStop) node).getBusCode() + " " + node.getAddress() + "\n";
             } else if (node instanceof TrainStation) {
-                message += ((TrainStation) node).getTrainCodes() + " " + node.getDescription() + "\n";
+                message += node.getAddress() + " " + node.getDescription() + "\n";
             } else if (node instanceof CustomNode)  {
                 message += node.getAddress() + "\n";
             }

--- a/src/main/java/duke/logic/parsers/commandparser/RouteNodeAddParser.java
+++ b/src/main/java/duke/logic/parsers/commandparser/RouteNodeAddParser.java
@@ -40,8 +40,6 @@ public class RouteNodeAddParser extends CommandParser {
                 throw new ParseException(Messages.ERROR_INPUT_INVALID_FORMAT);
             }
 
-            String[] indexes = withinDetails[0].split(" ");
-
             String type = userInput.substring(withinDetails[0].length()).strip().substring(0, 4);
             if (!("with".equals(type) || "at".equals(type.substring(0, 2)))) {
                 throw new ParseException(Messages.ERROR_INPUT_INVALID_FORMAT);

--- a/src/main/java/duke/model/locations/RouteNode.java
+++ b/src/main/java/duke/model/locations/RouteNode.java
@@ -57,7 +57,11 @@ public abstract class RouteNode extends Venue {
      * @return description The description of the RouteNode.
      */
     public String getDescription() {
-        return description;
+        if (!(description == null || description.equals("null"))) {
+            return description;
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/duke/model/locations/TrainStation.java
+++ b/src/main/java/duke/model/locations/TrainStation.java
@@ -42,11 +42,19 @@ public class TrainStation extends RouteNode {
      * @param model The model.
      */
     public void fetchData(Model model) {
+        String[] addressDetails = this.getAddress().split(" ");
+        StringBuilder addressSB = new StringBuilder();
+        for (String detail : addressDetails) {
+            addressSB.append(detail.toUpperCase(), 0, 1).append(detail.substring(1)).append(" ");
+        }
+        String address = addressSB.toString();
+        address = address.substring(0, address.length() - 1);
+
         HashMap<String, TrainStation> allTrainStations = model.getMap().getTrainMap();
-        if (allTrainStations.containsKey(this.getAddress())) {
-            this.setAddress(allTrainStations.get(this.getAddress()).getAddress());
-            this.setLatitude(allTrainStations.get(this.getAddress()).getLatitude());
-            this.setLongitude(allTrainStations.get(this.getAddress()).getLongitude());
+        if (allTrainStations.containsKey(address)) {
+            this.setAddress(address + " MRT");
+            this.setLatitude(allTrainStations.get(address).getLatitude());
+            this.setLongitude(allTrainStations.get(address).getLongitude());
         }
     }
 }

--- a/src/main/java/duke/model/locations/Venue.java
+++ b/src/main/java/duke/model/locations/Venue.java
@@ -116,10 +116,14 @@ public class Venue implements Serializable {
             return true;
         }
 
-        return getLatitude() == otherVenue.getLatitude()
-                && getLongitude() == otherVenue.getLongitude()
-                && getAddress().equals(otherVenue.getAddress())
-                && getDistX() == otherVenue.getDistX()
-                && getDistY() == otherVenue.getDistY();
+        try {
+            return getLatitude() == otherVenue.getLatitude()
+                    && getLongitude() == otherVenue.getLongitude()
+                    && getAddress().equals(otherVenue.getAddress())
+                    && getDistX() == otherVenue.getDistX()
+                    && getDistY() == otherVenue.getDistY();
+        } catch (NullPointerException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/duke/model/transports/Route.java
+++ b/src/main/java/duke/model/transports/Route.java
@@ -144,12 +144,7 @@ public class Route {
     public void addNode(RouteNode newNode, int index) throws RouteNodeDuplicateException, QueryOutOfBoundsException {
         if (index >= 0 && index <= nodes.size()) {
             for (RouteNode node : nodes) {
-                if (node instanceof BusStop && newNode instanceof BusStop
-                        && ((BusStop) node).getBusCode().equals(((BusStop) newNode).getBusCode())) {
-                    throw new RouteNodeDuplicateException();
-                }
-                if (node instanceof TrainStation && newNode instanceof TrainStation
-                        && ((TrainStation) node).getTrainCodes().equals(((TrainStation) newNode).getTrainCodes())) {
+                if (node.equals(newNode)) {
                     throw new RouteNodeDuplicateException();
                 }
             }
@@ -168,12 +163,7 @@ public class Route {
      */
     public void addNode(RouteNode newNode) throws RouteNodeDuplicateException {
         for (RouteNode node: nodes) {
-            if (node instanceof BusStop && newNode instanceof BusStop
-                    && ((BusStop) node).getBusCode().equals(((BusStop) newNode).getBusCode())) {
-                throw new RouteNodeDuplicateException();
-            }
-            if (node instanceof TrainStation && newNode instanceof TrainStation
-                    && ((TrainStation) node).getTrainCodes().equals(((TrainStation) newNode).getTrainCodes())) {
+            if (node.equals(newNode)) {
                 throw new RouteNodeDuplicateException();
             }
         }

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -120,6 +120,7 @@ public class MainWindow extends UiPart<Stage> {
                 if (result instanceof CommandResultMap) {
                     new MapWindow((CommandResultMap) result).show();
                 }
+
             } catch (DukeException | FileNotFoundException e) {
                 sgTravelShow(e.getMessage());
             }


### PR DESCRIPTION
Fix:

	 - Fix RouteGenerateCommand crashing when it cannot find a path.
		 - Now throws RouteGenerateFailException.
	
	 - Fix RouteNodeShowCommand OOB

	 - Fix RouteNearby OOB
	 
	 - Fix RouteNodeAdd for TrainStation
		 - Now fetches information properly, and shows the correct Node.
		 
	 - Fix RouteNearby for TrainStation
	 
	 - Fix routeList for TrainStation
		 - Now shows proper information
	 
	 - Removed mixed option for RouteGenerate for now
		 - Commmand requires fix in PathFinder for mixed option
		 - Removed "Hybrid" option in FindPathCommand too for now.
		 - Example error is: routeGenerate amk hub to sungei gedong by mixed